### PR TITLE
EVM: Add missing revert reasons

### DIFF
--- a/packages/evm/contracts/lib/RLP.sol
+++ b/packages/evm/contracts/lib/RLP.sol
@@ -36,7 +36,7 @@ library RLP {
     * @param item RLP encoded list in bytes
     */
     function toList(RLPItem memory item) internal pure returns (RLPItem[] memory result) {
-        require(isList(item));
+        require(isList(item), "Cannot convert to list a non-list RLPItem.");
 
         uint items = numItems(item);
         result = new RLPItem[](items);

--- a/packages/evm/contracts/lib/TrieProofs.sol
+++ b/packages/evm/contracts/lib/TrieProofs.sol
@@ -134,16 +134,16 @@ library TrieProofs {
     * Nibble is extracted as the least significant nibble in the returned byte
     */
     function extractNibble(bytes32 path, uint256 position) internal pure returns (uint8 nibble) {
-        require(position < 64);
+        require(position < 64, "Invalid nibble position");
         byte shifted = position == 0 ? byte(path >> 4) : byte(path << ((position - 1) * 4));
         return uint8(byte(shifted & 0xF));
     }
 
     function decodeNibbles(bytes memory compact, uint skipNibbles) internal pure returns (bytes memory nibbles) {
-        require(compact.length > 0);
+        require(compact.length > 0, "Empty bytes array");
 
         uint length = compact.length * 2;
-        require(skipNibbles <= length);
+        require(skipNibbles <= length, "Skip nibbles amount too large");
         length -= skipNibbles;
 
         nibbles = new bytes(length);


### PR DESCRIPTION
Adding missing revert reasons in `RLP` and `TrieProofs` libraries